### PR TITLE
Feature | Select best and worst stock according to selected filter

### DIFF
--- a/domain/src/main/java/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectBestDailyStockShareCase.kt
+++ b/domain/src/main/java/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectBestDailyStockShareCase.kt
@@ -3,13 +3,16 @@ package com.mctech.stocktradetracking.domain.stock_share.interaction
 import com.mctech.stocktradetracking.domain.stock_share.entity.SelectedStock
 import com.mctech.stocktradetracking.domain.stock_share.entity.StockShare
 import com.mctech.stocktradetracking.domain.stock_share.interaction.strategies.SelectStockStrategy
+import com.mctech.stocktradetracking.domain.stock_share_filter.entity.RankingQualifier
+import com.mctech.stocktradetracking.domain.stock_share_filter.entity.StockFilter
 
 class SelectBestDailyStockShareCase(
   private val groupStockShareListCase: GroupStockShareListCase
 ) : SelectStockStrategy {
-  override fun execute(stockShareList: List<StockShare>): SelectedStock? {
+
+  override fun execute(stockShareList: List<StockShare>, filter: StockFilter): SelectedStock? {
     return groupStockShareListCase.transform(stockShareList).maxBy {
-      it.getDailyVariationBalance()
+      selectMaxByFilter(filter, it)
     }?.let {
       SelectedStock(
         it.code,
@@ -17,6 +20,13 @@ class SelectBestDailyStockShareCase(
         it.getDailyVariationDescription(),
         it.getDailyVariationBalance()
       )
+    }
+  }
+
+  private fun selectMaxByFilter(filter: StockFilter, item: StockShare): Double {
+    return when (filter.rankingQualifier) {
+      RankingQualifier.Balance -> item.getDailyVariationBalance()
+      RankingQualifier.Percent -> item.getDailyVariation()
     }
   }
 }

--- a/domain/src/main/java/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectBestStockShareCase.kt
+++ b/domain/src/main/java/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectBestStockShareCase.kt
@@ -3,13 +3,15 @@ package com.mctech.stocktradetracking.domain.stock_share.interaction
 import com.mctech.stocktradetracking.domain.stock_share.entity.SelectedStock
 import com.mctech.stocktradetracking.domain.stock_share.entity.StockShare
 import com.mctech.stocktradetracking.domain.stock_share.interaction.strategies.SelectStockStrategy
+import com.mctech.stocktradetracking.domain.stock_share_filter.entity.RankingQualifier
+import com.mctech.stocktradetracking.domain.stock_share_filter.entity.StockFilter
 
 class SelectBestStockShareCase(
   private val groupStockShareListCase: GroupStockShareListCase
 ) : SelectStockStrategy {
-  override fun execute(stockShareList: List<StockShare>): SelectedStock? {
+  override fun execute(stockShareList: List<StockShare>, filter: StockFilter): SelectedStock? {
     return groupStockShareListCase.transform(stockShareList).maxBy {
-      it.getBalance()
+      selectMaxByFilter(filter, it)
     }?.let {
       SelectedStock(
         it.code,
@@ -17,6 +19,13 @@ class SelectBestStockShareCase(
         it.getVariationDescription(),
         it.getVariation()
       )
+    }
+  }
+
+  private fun selectMaxByFilter(filter: StockFilter, item: StockShare): Double {
+    return when (filter.rankingQualifier) {
+      RankingQualifier.Balance -> item.getBalance()
+      RankingQualifier.Percent -> item.getVariation()
     }
   }
 }

--- a/domain/src/main/java/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectWorstDailyStockShareCase.kt
+++ b/domain/src/main/java/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectWorstDailyStockShareCase.kt
@@ -3,13 +3,15 @@ package com.mctech.stocktradetracking.domain.stock_share.interaction
 import com.mctech.stocktradetracking.domain.stock_share.entity.SelectedStock
 import com.mctech.stocktradetracking.domain.stock_share.entity.StockShare
 import com.mctech.stocktradetracking.domain.stock_share.interaction.strategies.SelectStockStrategy
+import com.mctech.stocktradetracking.domain.stock_share_filter.entity.RankingQualifier
+import com.mctech.stocktradetracking.domain.stock_share_filter.entity.StockFilter
 
 class SelectWorstDailyStockShareCase(
   private val groupStockShareListCase: GroupStockShareListCase
 ) : SelectStockStrategy {
-  override fun execute(stockShareList: List<StockShare>): SelectedStock? {
+  override fun execute(stockShareList: List<StockShare>, filter: StockFilter): SelectedStock? {
     return groupStockShareListCase.transform(stockShareList).minBy {
-      it.getDailyVariationBalance()
+      selectMinByFilter(filter, it)
     }?.let {
       SelectedStock(
         it.code,
@@ -17,6 +19,13 @@ class SelectWorstDailyStockShareCase(
         it.getDailyVariationDescription(),
         it.getDailyVariation()
       )
+    }
+  }
+
+  private fun selectMinByFilter(filter: StockFilter, item: StockShare): Double {
+    return when (filter.rankingQualifier) {
+      RankingQualifier.Balance -> item.getDailyVariationBalance()
+      RankingQualifier.Percent -> item.getDailyVariation()
     }
   }
 }

--- a/domain/src/main/java/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectWorstStockShareCase.kt
+++ b/domain/src/main/java/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectWorstStockShareCase.kt
@@ -3,13 +3,15 @@ package com.mctech.stocktradetracking.domain.stock_share.interaction
 import com.mctech.stocktradetracking.domain.stock_share.entity.SelectedStock
 import com.mctech.stocktradetracking.domain.stock_share.entity.StockShare
 import com.mctech.stocktradetracking.domain.stock_share.interaction.strategies.SelectStockStrategy
+import com.mctech.stocktradetracking.domain.stock_share_filter.entity.RankingQualifier
+import com.mctech.stocktradetracking.domain.stock_share_filter.entity.StockFilter
 
 class SelectWorstStockShareCase(
   private val groupStockShareListCase: GroupStockShareListCase
 ) : SelectStockStrategy {
-  override fun execute(stockShareList: List<StockShare>): SelectedStock? {
+  override fun execute(stockShareList: List<StockShare>, filter: StockFilter): SelectedStock? {
     return groupStockShareListCase.transform(stockShareList).minBy {
-      it.getBalance()
+      selectMinByFilter(filter, it)
     }?.let {
       SelectedStock(
         it.code,
@@ -17,6 +19,13 @@ class SelectWorstStockShareCase(
         it.getVariationDescription(),
         it.getVariation()
       )
+    }
+  }
+
+  private fun selectMinByFilter(filter: StockFilter, item: StockShare): Double {
+    return when (filter.rankingQualifier) {
+      RankingQualifier.Balance -> item.getBalance()
+      RankingQualifier.Percent -> item.getVariation()
     }
   }
 }

--- a/domain/src/main/java/com/mctech/stocktradetracking/domain/stock_share/interaction/strategies/SelectStockStrategy.kt
+++ b/domain/src/main/java/com/mctech/stocktradetracking/domain/stock_share/interaction/strategies/SelectStockStrategy.kt
@@ -2,7 +2,8 @@ package com.mctech.stocktradetracking.domain.stock_share.interaction.strategies
 
 import com.mctech.stocktradetracking.domain.stock_share.entity.SelectedStock
 import com.mctech.stocktradetracking.domain.stock_share.entity.StockShare
+import com.mctech.stocktradetracking.domain.stock_share_filter.entity.StockFilter
 
 interface SelectStockStrategy {
-  fun execute(stockShareList: List<StockShare>): SelectedStock?
+  fun execute(stockShareList: List<StockShare>, filter: StockFilter): SelectedStock?
 }

--- a/domain/src/test/kotlin/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectBestDailyStockShareCaseTest.kt
+++ b/domain/src/test/kotlin/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectBestDailyStockShareCaseTest.kt
@@ -1,16 +1,19 @@
 package com.mctech.stocktradetracking.domain.stock_share.interaction
 
+import com.mctech.stocktradetracking.domain.stock_share_filter.entity.RankingQualifier
 import com.mctech.stocktradetracking.testing.data_factory.factories.StockShareDataFactory
+import com.mctech.stocktradetracking.testing.data_factory.factories.StockShareFilterDataFactory
 import com.mctech.stocktradetracking.testing.data_factory.testScenario
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test
 
-
 @ExperimentalCoroutinesApi
 class SelectBestDailyStockShareCaseTest {
   private lateinit var useCase: SelectBestDailyStockShareCase
+  private val balanceFilter = StockShareFilterDataFactory.single(ranking = RankingQualifier.Balance)
+  private val percentFilter = StockShareFilterDataFactory.single(ranking = RankingQualifier.Percent)
 
   @Before
   fun `before each test`() {
@@ -20,9 +23,23 @@ class SelectBestDailyStockShareCaseTest {
   }
 
   @Test
-  fun `should group list by code`() = testScenario(
+  fun `should return best daily stock by balance`() = testScenario(
     action = {
-      useCase.execute(StockShareDataFactory.ungroupedList())
+      useCase.execute(StockShareDataFactory.ungroupedList(), balanceFilter)
+    },
+    assertions = { mglu ->
+      Assertions.assertThat(mglu).isNotNull
+      Assertions.assertThat(mglu?.code).isEqualTo("MGLU3")
+      Assertions.assertThat(mglu?.balanceDescription).isEqualTo("R$1.400,00")
+      Assertions.assertThat(mglu?.variation).isEqualTo(1400.0)
+      Assertions.assertThat(mglu?.variationDescription).isEqualTo("25.0%")
+    }
+  )
+
+  @Test
+  fun `should return best daily stock by percent`() = testScenario(
+    action = {
+      useCase.execute(StockShareDataFactory.ungroupedList(), percentFilter)
     },
     assertions = { mglu ->
       Assertions.assertThat(mglu).isNotNull

--- a/domain/src/test/kotlin/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectBestStockShareCaseTest.kt
+++ b/domain/src/test/kotlin/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectBestStockShareCaseTest.kt
@@ -1,6 +1,8 @@
 package com.mctech.stocktradetracking.domain.stock_share.interaction
 
+import com.mctech.stocktradetracking.domain.stock_share_filter.entity.RankingQualifier
 import com.mctech.stocktradetracking.testing.data_factory.factories.StockShareDataFactory
+import com.mctech.stocktradetracking.testing.data_factory.factories.StockShareFilterDataFactory
 import com.mctech.stocktradetracking.testing.data_factory.testScenario
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -10,6 +12,8 @@ import org.junit.Test
 @ExperimentalCoroutinesApi
 class SelectBestStockShareCaseTest {
   private lateinit var useCase: SelectBestStockShareCase
+  private val balanceFilter = StockShareFilterDataFactory.single(ranking = RankingQualifier.Balance)
+  private val percentFilter = StockShareFilterDataFactory.single(ranking = RankingQualifier.Percent)
 
   @Before
   fun `before each test`() {
@@ -19,9 +23,23 @@ class SelectBestStockShareCaseTest {
   }
 
   @Test
-  fun `should group list by code`() = testScenario(
+  fun `should return best stock by balance`() = testScenario(
     action = {
-      useCase.execute(StockShareDataFactory.ungroupedList())
+      useCase.execute(StockShareDataFactory.ungroupedList(), balanceFilter)
+    },
+    assertions = { mglu ->
+      assertThat(mglu).isNotNull
+      assertThat(mglu?.code).isEqualTo("MGLU3")
+      assertThat(mglu?.balanceDescription).isEqualTo("R$1.800,00")
+      assertThat(mglu?.variation).isEqualTo(34.62)
+      assertThat(mglu?.variationDescription).isEqualTo("34.62%")
+    }
+  )
+
+  @Test
+  fun `should return best stock by percent`() = testScenario(
+    action = {
+      useCase.execute(StockShareDataFactory.ungroupedList(), percentFilter)
     },
     assertions = { mglu ->
       assertThat(mglu).isNotNull

--- a/domain/src/test/kotlin/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectWorstDailyStockShareCaseTest.kt
+++ b/domain/src/test/kotlin/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectWorstDailyStockShareCaseTest.kt
@@ -1,6 +1,8 @@
 package com.mctech.stocktradetracking.domain.stock_share.interaction
 
+import com.mctech.stocktradetracking.domain.stock_share_filter.entity.RankingQualifier
 import com.mctech.stocktradetracking.testing.data_factory.factories.StockShareDataFactory
+import com.mctech.stocktradetracking.testing.data_factory.factories.StockShareFilterDataFactory
 import com.mctech.stocktradetracking.testing.data_factory.testScenario
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions
@@ -10,6 +12,8 @@ import org.junit.Test
 @ExperimentalCoroutinesApi
 class SelectWorstDailyStockShareCaseTest {
   private lateinit var useCase: SelectWorstDailyStockShareCase
+  private val balanceFilter = StockShareFilterDataFactory.single(ranking = RankingQualifier.Balance)
+  private val percentFilter = StockShareFilterDataFactory.single(ranking = RankingQualifier.Percent)
 
   @Before
   fun `before each test`() {
@@ -19,9 +23,23 @@ class SelectWorstDailyStockShareCaseTest {
   }
 
   @Test
-  fun `should group list by code`() = testScenario(
+  fun `should return worst daily stock by balance`() = testScenario(
     action = {
-      useCase.execute(StockShareDataFactory.ungroupedList())
+      useCase.execute(StockShareDataFactory.ungroupedList(), balanceFilter)
+    },
+    assertions = { wege3 ->
+      Assertions.assertThat(wege3).isNotNull
+      Assertions.assertThat(wege3?.code).isEqualTo("WEGE3")
+      Assertions.assertThat(wege3?.balanceDescription).isEqualTo("-R$4.800,00")
+      Assertions.assertThat(wege3?.variation).isEqualTo(-80.00)
+      Assertions.assertThat(wege3?.variationDescription).isEqualTo("-80.0%")
+    }
+  )
+
+  @Test
+  fun `should return worst daily stock by percent`() = testScenario(
+    action = {
+      useCase.execute(StockShareDataFactory.ungroupedList(), percentFilter)
     },
     assertions = { wege3 ->
       Assertions.assertThat(wege3).isNotNull

--- a/domain/src/test/kotlin/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectWorstStockShareCaseTest.kt
+++ b/domain/src/test/kotlin/com/mctech/stocktradetracking/domain/stock_share/interaction/SelectWorstStockShareCaseTest.kt
@@ -1,6 +1,8 @@
 package com.mctech.stocktradetracking.domain.stock_share.interaction
 
+import com.mctech.stocktradetracking.domain.stock_share_filter.entity.RankingQualifier
 import com.mctech.stocktradetracking.testing.data_factory.factories.StockShareDataFactory
+import com.mctech.stocktradetracking.testing.data_factory.factories.StockShareFilterDataFactory
 import com.mctech.stocktradetracking.testing.data_factory.testScenario
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -10,6 +12,8 @@ import org.junit.Test
 @ExperimentalCoroutinesApi
 class SelectWorstStockShareCaseTest {
   private lateinit var useCase: SelectWorstStockShareCase
+  private val balanceFilter = StockShareFilterDataFactory.single(ranking = RankingQualifier.Balance)
+  private val percentFilter = StockShareFilterDataFactory.single(ranking = RankingQualifier.Percent)
 
   @Before
   fun `before each test`() {
@@ -19,9 +23,23 @@ class SelectWorstStockShareCaseTest {
   }
 
   @Test
-  fun `should group list by code`() = testScenario(
+  fun `should return worst stock by balance`() = testScenario(
     action = {
-      useCase.execute(StockShareDataFactory.ungroupedList())
+      useCase.execute(StockShareDataFactory.ungroupedList(), balanceFilter)
+    },
+    assertions = { wege3 ->
+      assertThat(wege3).isNotNull
+      assertThat(wege3?.code).isEqualTo("WEGE3")
+      assertThat(wege3?.balanceDescription).isEqualTo("-R$1.000,00")
+      assertThat(wege3?.variation).isEqualTo(-45.45)
+      assertThat(wege3?.variationDescription).isEqualTo("-45.45%")
+    }
+  )
+
+  @Test
+  fun `should return worst stock by percent`() = testScenario(
+    action = {
+      useCase.execute(StockShareDataFactory.ungroupedList(), percentFilter)
     },
     assertions = { wege3 ->
       assertThat(wege3).isNotNull

--- a/features/feature-stock-share/src/main/java/com/mctech/stocktradetracking/feature/stock_share/list_position/StockShareListViewModel.kt
+++ b/features/feature-stock-share/src/main/java/com/mctech/stocktradetracking/feature/stock_share/list_position/StockShareListViewModel.kt
@@ -104,7 +104,7 @@ open class StockShareListViewModel constructor(
         StockShareListResult(list, filter)
       }
       .collect { result ->
-        computeStockScore(result.list)
+        computeStockScore(result)
         organizeStockListBeforeShowIt(result)
       }
   }
@@ -156,14 +156,14 @@ open class StockShareListViewModel constructor(
     _shareList.changeToSuccessState(stockShareList)
   }
 
-  private fun computeStockScore(stockShareList: List<StockShare>) {
+  private fun computeStockScore(result: StockShareListResult) {
     dataTransformerScope?.cancel()
 
     dataTransformerScope = viewModelScope + Job()
 
-    dataTransformerScope?.async { computeFinalBalance(stockShareList) }
-    dataTransformerScope?.async { computeBestStock(stockShareList) }
-    dataTransformerScope?.async { computeWorstStock(stockShareList) }
+    dataTransformerScope?.async { computeFinalBalance(result.list) }
+    dataTransformerScope?.async { computeBestStock(result) }
+    dataTransformerScope?.async { computeWorstStock(result) }
   }
 
   private fun computeFinalBalance(stockShareList: List<StockShare>) {
@@ -173,17 +173,17 @@ open class StockShareListViewModel constructor(
     )
   }
 
-  private fun computeWorstStock(stockShareList: List<StockShare>) {
+  private fun computeWorstStock(result: StockShareListResult) {
     _worstStockShare.changeToLoadingState()
     _worstStockShare.changeToSuccessState(
-      selectWorstStockShareCase.execute(stockShareList)
+      selectWorstStockShareCase.execute(result.list, result.filter)
     )
   }
 
-  private fun computeBestStock(stockShareList: List<StockShare>) {
+  private fun computeBestStock(result: StockShareListResult) {
     _bestStockShare.changeToLoadingState()
     _bestStockShare.changeToSuccessState(
-      selectBestStockShareCase.execute(stockShareList)
+      selectBestStockShareCase.execute(result.list, result.filter)
     )
   }
 


### PR DESCRIPTION
## Context 
It's been a while since the release with the filter version where you can sort your stock list according to the criteria you select on filter screen. 

There are a options on filter screen called `Rank best and worst by` that was never implemented by now. So here is the PR 